### PR TITLE
Change cur to con to resolve attribute error

### DIFF
--- a/lec_multi_insert.py
+++ b/lec_multi_insert.py
@@ -8,5 +8,5 @@ people = [('Simon','Tam','Doctor'), ('River','Tam',None)]
 cur.executemany('''INSERT INTO staff (forename, surname, job)
                    VALUES (?,?,?)''', people)
 
-cur.commit()
+con.commit()
 con.close()


### PR DESCRIPTION
Seems that `.commit()` isn't an attribute of cursor but of connection.

Looking at -

https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.commit

SO post -

http://stackoverflow.com/a/20860210/3130747
